### PR TITLE
Fixed typo in sequence.setPhosPhoSites

### DIFF
--- a/localcider/backend/sequence.py
+++ b/localcider/backend/sequence.py
@@ -1620,7 +1620,7 @@ class Sequence:
         if isinstance(listOfPsites, int):
             tmp = listOfPsites
             listOfPsites = []
-            listOfPsites.appned(tmp)
+            listOfPsites.append(tmp)
 
         # evaluate proposed phosphosites
         for site in listOfPsites:


### PR DESCRIPTION
Corrected an issue whereby a typo resulted in an issue in adding phosphorylation sites to a sequence (and by extension, a SequenceParameters object)